### PR TITLE
영어 스크립트 게시글 등록 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
@@ -1,0 +1,41 @@
+package com.teamhyeok.harmonyenglishacademy.api.controller;
+
+import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.Map;
+
+@RequestMapping("/api/v1/english-transcript")
+@RestController
+public class EnglishTranscriptController {
+
+    @PostMapping
+    public ResponseEntity<Map<String, String>> register(@RequestBody EnglishTranscriptCreate request) {
+        // TODO 1. 게시글 등록 실패시 400 Bad Request 반환
+        final URI REDIRECT_TO_MAIN_PAGE_URL = URI.create("/api/v1/english-transcripts");
+
+
+        // TODO 1. Title validation check (type1)
+
+        if (request.getTitle() == null || request.getTitle().isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        if (request.getContent() == null | request.getContent().isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        if (request.getTitle().length() < 2 || request.getTitle().length() > 100) {
+            return ResponseEntity.badRequest().build();
+        } // .. 등등 직접 컨트롤러 안에서 유효성 검증 처리 구현, 벌써 복잡해진다.
+
+
+        return ResponseEntity.created(REDIRECT_TO_MAIN_PAGE_URL).build();
+    }
+
+}

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
@@ -1,7 +1,9 @@
 package com.teamhyeok.harmonyenglishacademy.api.controller;
 
 import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
+import com.teamhyeok.harmonyenglishacademy.api.service.EnglishTranscriptService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,16 +14,19 @@ import java.net.URI;
 import java.util.Map;
 
 @RequestMapping("/api/v1/english-transcript")
-@RestController
+@RequiredArgsConstructor @RestController
 public class EnglishTranscriptController {
 
+    private final EnglishTranscriptService englishTranscriptService;
     @PostMapping
-    public ResponseEntity<Map<String, String>> register(@RequestBody @Valid EnglishTranscriptCreate request) {
-        // TODO 1. 게시글 등록 실패시 400 Bad Request 반환
+    public ResponseEntity<Map<String, String>> register(
+            @RequestBody @Valid EnglishTranscriptCreate request
+    ) {
         final URI REDIRECT_TO_MAIN_PAGE_URL = URI.create("/api/v1/english-transcripts");
-
+        englishTranscriptService.createTranscript(request);
 
         return ResponseEntity.created(REDIRECT_TO_MAIN_PAGE_URL).build();
     }
+
 
 }

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
@@ -1,13 +1,18 @@
 package com.teamhyeok.harmonyenglishacademy.api.controller;
 
 import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RequestMapping("/api/v1/english-transcript")
@@ -15,25 +20,25 @@ import java.util.Map;
 public class EnglishTranscriptController {
 
     @PostMapping
-    public ResponseEntity<Map<String, String>> register(@RequestBody EnglishTranscriptCreate request) {
+    public ResponseEntity<Map<String, String>> register(@RequestBody @Valid EnglishTranscriptCreate request, BindingResult result) {
         // TODO 1. 게시글 등록 실패시 400 Bad Request 반환
         final URI REDIRECT_TO_MAIN_PAGE_URL = URI.create("/api/v1/english-transcripts");
 
+        // TODO 2. Title validation check (type2)
+        /* EnglishTranscriptCreate에 valid 애노테이션 적용하는 방법 */
 
-        // TODO 1. Title validation check (type1)
+        if (result.hasErrors()) {
+            List<FieldError> fieldErrors = result.getFieldErrors();
+            FieldError firstFieldError = fieldErrors.get(0);
+            String fieldName = firstFieldError.getField();
+            String errorMessage = firstFieldError.getDefaultMessage();
 
-        if (request.getTitle() == null || request.getTitle().isEmpty()) {
-            return ResponseEntity.badRequest().build();
+            Map<String, String> error = new HashMap<>();
+            error.put("field", fieldName);
+            error.put("errorMessage", errorMessage);
+
+            return ResponseEntity.badRequest().body(error);
         }
-
-        if (request.getContent() == null | request.getContent().isEmpty()) {
-            return ResponseEntity.badRequest().build();
-        }
-
-        if (request.getTitle().length() < 2 || request.getTitle().length() > 100) {
-            return ResponseEntity.badRequest().build();
-        } // .. 등등 직접 컨트롤러 안에서 유효성 검증 처리 구현, 벌써 복잡해진다.
-
 
         return ResponseEntity.created(REDIRECT_TO_MAIN_PAGE_URL).build();
     }

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
@@ -3,16 +3,12 @@ package com.teamhyeok.harmonyenglishacademy.api.controller;
 import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @RequestMapping("/api/v1/english-transcript")
@@ -20,25 +16,10 @@ import java.util.Map;
 public class EnglishTranscriptController {
 
     @PostMapping
-    public ResponseEntity<Map<String, String>> register(@RequestBody @Valid EnglishTranscriptCreate request, BindingResult result) {
+    public ResponseEntity<Map<String, String>> register(@RequestBody @Valid EnglishTranscriptCreate request) {
         // TODO 1. 게시글 등록 실패시 400 Bad Request 반환
         final URI REDIRECT_TO_MAIN_PAGE_URL = URI.create("/api/v1/english-transcripts");
 
-        // TODO 2. Title validation check (type2)
-        /* EnglishTranscriptCreate에 valid 애노테이션 적용하는 방법 */
-
-        if (result.hasErrors()) {
-            List<FieldError> fieldErrors = result.getFieldErrors();
-            FieldError firstFieldError = fieldErrors.get(0);
-            String fieldName = firstFieldError.getField();
-            String errorMessage = firstFieldError.getDefaultMessage();
-
-            Map<String, String> error = new HashMap<>();
-            error.put("field", fieldName);
-            error.put("errorMessage", errorMessage);
-
-            return ResponseEntity.badRequest().body(error);
-        }
 
         return ResponseEntity.created(REDIRECT_TO_MAIN_PAGE_URL).build();
     }

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptController.java
@@ -1,16 +1,15 @@
 package com.teamhyeok.harmonyenglishacademy.api.controller;
 
+import com.teamhyeok.harmonyenglishacademy.api.domain.EnglishTranscript;
 import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
 import com.teamhyeok.harmonyenglishacademy.api.service.EnglishTranscriptService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 @RequestMapping("/api/v1/english-transcript")
@@ -29,4 +28,15 @@ public class EnglishTranscriptController {
     }
 
 
+    @GetMapping("/search")
+    public ResponseEntity<List<EnglishTranscript>> searchTranscriptByTitle(
+            @RequestParam String title,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        List<EnglishTranscript> transcript = englishTranscriptService.searchTranscriptByTitle(title, page, size);
+        return ResponseEntity.ok(transcript);
+    }
+
 }
+

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/ExceptionController.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/ExceptionController.java
@@ -1,0 +1,29 @@
+package com.teamhyeok.harmonyenglishacademy.api.controller;
+
+import com.teamhyeok.harmonyenglishacademy.api.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice @Slf4j
+public class ExceptionController {
+
+
+    @ExceptionHandler(MethodArgumentNotValidException.class) @ResponseBody @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse invalidRequestHandler(MethodArgumentNotValidException e) {
+
+        ErrorResponse errorResponse = new ErrorResponse("400", "잘못된 요청입니다.");
+
+        for (FieldError fieldError : e.getFieldErrors()) {
+            errorResponse.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        return errorResponse;
+    }
+
+}

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/ExceptionController.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/ExceptionController.java
@@ -17,7 +17,10 @@ public class ExceptionController {
     @ExceptionHandler(MethodArgumentNotValidException.class) @ResponseBody @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse invalidRequestHandler(MethodArgumentNotValidException e) {
 
-        ErrorResponse errorResponse = new ErrorResponse("400", "잘못된 요청입니다.");
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code("400")
+                .message("잘못된 요청입니다.")
+                .build();
 
         for (FieldError fieldError : e.getFieldErrors()) {
             errorResponse.addValidation(fieldError.getField(), fieldError.getDefaultMessage());

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
@@ -1,0 +1,39 @@
+package com.teamhyeok.harmonyenglishacademy.api.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity @Getter @NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class EnglishTranscript {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Lob
+    private String content;
+
+    @CreatedDate
+    @JsonFormat(pattern = "yyyy-mm-dd'T'HH:mm:ss")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public EnglishTranscript(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/repository/EnglishTranscriptRepository.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/repository/EnglishTranscriptRepository.java
@@ -1,0 +1,9 @@
+package com.teamhyeok.harmonyenglishacademy.api.repository;
+
+import com.teamhyeok.harmonyenglishacademy.api.domain.EnglishTranscript;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface EnglishTranscriptRepository extends JpaRepository<EnglishTranscript, Long>{
+
+}

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/repository/EnglishTranscriptRepository.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/repository/EnglishTranscriptRepository.java
@@ -1,9 +1,14 @@
 package com.teamhyeok.harmonyenglishacademy.api.repository;
 
 import com.teamhyeok.harmonyenglishacademy.api.domain.EnglishTranscript;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface EnglishTranscriptRepository extends JpaRepository<EnglishTranscript, Long>{
 
+    Page<EnglishTranscript> findByTitleContainingIgnoreCase(String title, Pageable pageable);
+
 }
+

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/request/EnglishTranscriptCreate.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/request/EnglishTranscriptCreate.java
@@ -1,25 +1,32 @@
 package com.teamhyeok.harmonyenglishacademy.api.request;
 
 
+import com.teamhyeok.harmonyenglishacademy.api.domain.EnglishTranscript;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class EnglishTranscriptCreate {
 
-
-    // TODO 2. request validation check (type2)
     @NotBlank(message = "영어 스크립트 게시글 등록을 위해선 이름이 필요합니다.")
     private String title;
 
     @NotBlank(message = "영어 스크립트 게시글 등록을 위해선 내용이 필요합니다.")
     private String content;
 
-    /* valid annotation 적용해서 유효성 검증을 진행하는 방법 */
+    public EnglishTranscript toEntity() {
 
+        return EnglishTranscript.builder()
+                .title(title)
+                .content(content)
+                .build();
+    }
 
-
+    @Builder
+    public EnglishTranscriptCreate(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 
 }

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/request/EnglishTranscriptCreate.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/request/EnglishTranscriptCreate.java
@@ -1,0 +1,25 @@
+package com.teamhyeok.harmonyenglishacademy.api.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class EnglishTranscriptCreate {
+
+
+    // TODO 2. request validation check (type2)
+    @NotBlank(message = "영어 스크립트 게시글 등록을 위해선 이름이 필요합니다.")
+    private String title;
+
+    @NotBlank(message = "영어 스크립트 게시글 등록을 위해선 내용이 필요합니다.")
+    private String content;
+
+    /* valid annotation 적용해서 유효성 검증을 진행하는 방법 */
+
+
+
+
+}

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/response/ErrorResponse.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/response/ErrorResponse.java
@@ -1,7 +1,7 @@
 package com.teamhyeok.harmonyenglishacademy.api.response;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,12 +17,18 @@ import java.util.Map;
  *     }
  * }
  */
-@Getter @RequiredArgsConstructor
+@Getter
 public class ErrorResponse {
 
     private final String code;
     private final String message;
     private final Map<String, String> validation = new HashMap<>();
+
+    @Builder
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
 
     public void addValidation(String fieldName, String errorMessage) {
         validation.put(fieldName, errorMessage);

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/response/ErrorResponse.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/response/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.teamhyeok.harmonyenglishacademy.api.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * {
+ *     "code": "400",
+ *     "message": "잘못된 요청입니다"
+ *     "validation": {
+ *         "title": "값을 입력해주세요",
+ *         "content": ...
+ *     }
+ * }
+ */
+@Getter @RequiredArgsConstructor
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final Map<String, String> validation = new HashMap<>();
+
+    public void addValidation(String fieldName, String errorMessage) {
+        validation.put(fieldName, errorMessage);
+    }
+}

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/service/EnglishTranscriptService.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/service/EnglishTranscriptService.java
@@ -1,0 +1,18 @@
+package com.teamhyeok.harmonyenglishacademy.api.service;
+
+import com.teamhyeok.harmonyenglishacademy.api.repository.EnglishTranscriptRepository;
+import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor @Service
+public class EnglishTranscriptService {
+    private final EnglishTranscriptRepository englishTranscriptRepository;
+
+    public void createTranscript(EnglishTranscriptCreate englishTranscriptCreate) {
+
+        englishTranscriptRepository.save(englishTranscriptCreate.toEntity());
+
+    }
+
+}

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/service/EnglishTranscriptService.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/service/EnglishTranscriptService.java
@@ -1,9 +1,15 @@
 package com.teamhyeok.harmonyenglishacademy.api.service;
 
+import com.teamhyeok.harmonyenglishacademy.api.domain.EnglishTranscript;
 import com.teamhyeok.harmonyenglishacademy.api.repository.EnglishTranscriptRepository;
 import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor @Service
 public class EnglishTranscriptService {
@@ -15,4 +21,10 @@ public class EnglishTranscriptService {
 
     }
 
+    public List<EnglishTranscript> searchTranscriptByTitle(String title, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<EnglishTranscript> pageOfEnglishTranscript = englishTranscriptRepository.findByTitleContainingIgnoreCase(title, pageable);
+        return pageOfEnglishTranscript.getContent();
+    }
 }
+

--- a/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
+++ b/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
@@ -78,5 +78,36 @@ class EnglishTranscriptControllerTest {
 
     }
 
+    @DisplayName("/api/v1/english-transcript에 POST 요청 이후 해당 게시글이 DB를 통해 정상적으로 조회된다.")
+    @Test
+    void register_save_transcript() throws Exception {
+
+        // given
+        String uuidTitle = "Glee season1 (ep1) - " + UUID.randomUUID();
+        EnglishTranscriptCreate request = EnglishTranscriptCreate.builder()
+                .title(uuidTitle)
+                .content("the series ...@#!#")
+                .build();
+
+        String stringRequest = objectMapper.writeValueAsString(request);
+
+
+        // when
+        mockMvc.perform(post("/api/v1/english-transcript")
+                        .contentType(APPLICATION_JSON)
+                        .content(stringRequest)
+                )
+                .andExpect(status().isCreated())
+                .andDo(print());
+
+        // then - 등록된 게시글 제목으로 조회
+        mockMvc.perform(get("/api/v1/english-transcript/search")
+                        .param("title", uuidTitle)
+                        .param("page", "1")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value(uuidTitle))
+                .andDo(print());
+    }
 
 }

--- a/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
+++ b/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
@@ -1,0 +1,53 @@
+package com.teamhyeok.harmonyenglishacademy.api.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest
+class EnglishTranscriptControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+
+    @DisplayName("게시글 등록 요청시 OK 헤더가 내려온다.")
+    @Test
+    void register() throws Exception{
+
+        // expected
+        mockMvc.perform(post("/api/v1/english-transcript")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"The Glee, season2 ep.3\", \"content\": \"the series ...@#!#\"}")
+                )
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/v1/english-transcripts"))
+                .andDo(MockMvcResultHandlers.print());
+
+    }
+
+
+    @DisplayName("게시글 등록 요청시 제목은 필수로 기입되어야 한다.")
+    @Test
+    void register_title_is_required() throws Exception {
+
+        // expected
+        mockMvc.perform(post("/api/v1/english-transcript")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"\", \"content\": \"the series ...@#!#\"}")
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.field").value("title"))
+                .andExpect(jsonPath("$.errorMessage").value("영어 스크립트 게시글 등록을 위해선 이름이 필요합니다."))
+                .andDo(MockMvcResultHandlers.print());
+
+    }
+
+}

--- a/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
+++ b/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
@@ -6,9 +6,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest
@@ -29,7 +29,7 @@ class EnglishTranscriptControllerTest {
                 )
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/v1/english-transcripts"))
-                .andDo(MockMvcResultHandlers.print());
+                .andDo(print());
 
     }
 
@@ -44,9 +44,10 @@ class EnglishTranscriptControllerTest {
                         .content("{\"title\": \"\", \"content\": \"the series ...@#!#\"}")
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.field").value("title"))
-                .andExpect(jsonPath("$.errorMessage").value("영어 스크립트 게시글 등록을 위해선 이름이 필요합니다."))
-                .andDo(MockMvcResultHandlers.print());
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.validation.title").value("타이틀을 입력해주세요."))
+                .andDo(print());
 
     }
 

--- a/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
+++ b/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
@@ -1,31 +1,50 @@
 package com.teamhyeok.harmonyenglishacademy.api.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamhyeok.harmonyenglishacademy.api.repository.EnglishTranscriptRepository;
+import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.http.MediaType;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.UUID;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest
+@AutoConfigureMockMvc @SpringBootTest
 class EnglishTranscriptControllerTest {
+
+    @Autowired
+    ObjectMapper objectMapper;
 
     @Autowired
     MockMvc mockMvc;
 
+    @Autowired
+    EnglishTranscriptRepository englishTranscriptRepository;
 
-    @DisplayName("게시글 등록 요청시 OK 헤더가 내려온다.")
+    @DisplayName("게시글 등록 요청시 IS_CREATED 헤더가 내려온다.")
     @Test
     void register() throws Exception{
+        // given
+        EnglishTranscriptCreate request = EnglishTranscriptCreate.builder()
+                                            .title("The Glee, season2 ep.3")
+                                            .content("the series ...@#!#")
+                                            .build();
+
+        String stringRequest = objectMapper.writeValueAsString(request);
 
         // expected
         mockMvc.perform(post("/api/v1/english-transcript")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\": \"The Glee, season2 ep.3\", \"content\": \"the series ...@#!#\"}")
+                        .contentType(APPLICATION_JSON)
+                        .content(stringRequest)
                 )
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/v1/english-transcripts"))
@@ -38,17 +57,26 @@ class EnglishTranscriptControllerTest {
     @Test
     void register_title_is_required() throws Exception {
 
+        // given
+        EnglishTranscriptCreate request = EnglishTranscriptCreate.builder()
+                .title("")
+                .content("the series ...@#!#")
+                .build();
+
+        String stringRequest = objectMapper.writeValueAsString(request);
+
         // expected
         mockMvc.perform(post("/api/v1/english-transcript")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\": \"\", \"content\": \"the series ...@#!#\"}")
+                        .contentType(APPLICATION_JSON)
+                        .content(stringRequest)
                 )
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"))
                 .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
-                .andExpect(jsonPath("$.validation.title").value("타이틀을 입력해주세요."))
+                .andExpect(jsonPath("$.validation.title").value("영어 스크립트 게시글 등록을 위해선 이름이 필요합니다."))
                 .andDo(print());
 
     }
+
 
 }


### PR DESCRIPTION
## a. 설명
> 1. 영어 스크립트 게시글 등록 기능 구현
- 게시글 등록 API 구현

> 2. 영어 스크립트 게시글 등록 예외처리
- 예외를 전역적으로 관리할 수 있게끔 핸들러 구현
- 게시글 등록 요청값 검증 구현

> 3. 영어 스크립트 게시글 등록 테스트 코드 작성
- 성공 테스트 (201 응답)
- 성공 테스트 (등록 이후 title 조회)
- 실패 테스트 (title이 비어있는 경우)

<br> 

## b. 작업 내용
> 1. 영어 스크립트 게시글 등록 API 구현을 위한 controller, service, repository 계층의 코드 작성
#### EnglishTranscriptCreate
- 요청에 대한 명세 및 검증의 책임을 수행할 EnglishTranscriptCreate 클래스 구현
- 요청 값 파싱 과정 외에도 테스트 코드등에서 가상 요청을 쉽게 만들때에도 사용

#### EnglishTranscriptController
- 영어 스크립트 게시글 등록 요청을 위한 컨트롤러

#### EnglishTranscriptService
- 영어 게시글 등록을 위해 컨트롤러로부터 제목, 내용을 입력받아 레포지토리 계층을 통해 DB에 적재 요청을 보내는 서비스

#### EnglishTranscript
- 영어 게시글 테이블과 매핑할 엔터티 클래스
- 현재는 id, title, content, created_at 으로 구성되어 있음


2. validation 라이브러리를 이용한 유효값 검증
- 컨트롤러에서 직접 검증하는 방법과 비교했을 때 큰 공수나 문제 없이 요청값에 대한 예외 처리를 간단하게 처리할 수 있어서 도입 결정
- 현재는 title, content에 대한 @Blank만 적용된 상태



## c. 작업 회고
> 1. 페이지 네이션 관련된 jpa 코드를 명확이 모르고 있는 상태였다.
```
    public List<EnglishTranscript> searchTranscriptByTitle(String title, int page, int size) {
        Pageable pageable = PageRequest.of(page - 1, size);
        Page<EnglishTranscript> pageOfEnglishTranscript = englishTranscriptRepository.findByTitleContainingIgnoreCase(title, pageable);
        return pageOfEnglishTranscript.getContent();
    }
```
- pageable이 무엇인지
- findByTitleContainingIgnoreCase를 하면 무슨 일이 일어나는지

> 2. 생성 날짜를 구하는 과정과 이를 위해 필요한 직렬화 과정에 대한 이해도가 낮은 상태였다.
```
    @CreatedDate
    @JsonFormat(pattern = "yyyy-mm-dd'T'HH:mm:ss")
    @JsonSerialize(using = LocalDateTimeSerializer.class)
    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
    private LocalDateTime createdAt;
```
- JsonFormat, JsonSerialize, JsonDeserialize 같은 것들이 어떤 애노테이션인지
- @CreatedDate는 어떤 역할을 수행하는지

## d. 기타 사항
> 별도 특이사항 없음
