### PR TITLE
[#13] 애플리케이션 health-check를 위한 restController와 테스트 코드 작성

### DIFF
--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/StatusController.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/controller/StatusController.java
@@ -1,0 +1,18 @@
+package com.teamhyeok.harmonyenglishacademy.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/")
+@RestController
+public class StatusController {
+
+    @GetMapping("/health-check")
+    public ResponseEntity<String> healthCheck() {
+
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/StatusControllerTest.java
+++ b/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/StatusControllerTest.java
@@ -1,0 +1,29 @@
+package com.teamhyeok.harmonyenglishacademy.api.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest
+class StatusControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @DisplayName("health-check 요청시 OK 헤더가 내려온다.")
+    @Test
+    void checkApiStatus() throws Exception {
+        mockMvc.perform(get("/api/v1/health-check"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+    }
+
+}


### PR DESCRIPTION
## a. 설명
> 1. health-check api 개발
- 서비스를 별도 클라우드 개발 서버로 올렸을 때 구동 여부를 간단히 확인하기 위한 api 필요
- 로드 밸런서가 부착된 환경에 올라갔을 때 health-check 기능 필요

## b. 작업 내용
> 1. `health-check api` 구현 

## c. 작업 회고
> 1. 적용 사유
- 향후 시스템 모니터링을 위해 그라파나, 프로메테우스 적용시에 액츄에이터를 적용해야 해서 굳이 필요한 작업인지 고민
- 결론은 모니터링 시스템 적용 전까지 사용할 health-check가 필요했고 액츄에이터를 지금 당장 도입해야 할 이유가 없어 도입키로함
- 적용에 필요한 공수도 10분 내외로 적어 큰 문제가 없다고 판단함

> 2. 향후 계획
- 액츄에이터 적용시 해당 API는 굳이 살려둘 필요가 없기에 제거할 계획
- 클라우드 환경의 개발 서버에 health-check를 해당 api로 등록했을 시 이 부분도 교체 필요