### PR TITLE
[#9] 기존 application.properties 구조에서 application.yml 구조로 변경

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=harmony-english-academy

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  profiles:
+    default: local
+  datasource:
+    url: jdbc:mysql://localhost:3306/hyeokDB
+    username: root
+    password: 1541
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+server:
+  port: 8087
+logging:
+  level:
+    org.springframework.cache: trace
+


### PR DESCRIPTION
## a. 설명
> 기존 application.properties 구조를 application.yml 구조로 변경

## b. 작업 내용

> 1. application.yml에 정의된 내용

- 서버 포트 8087 이용도록
- 스프링 캐시 조회 trace 레벨로 설정토록
- jpa ddl 설정 update로 적용토록
- mysql 접근 설정
- 해당 yml 프로필 설정 Local로

## c. 작업 회고
> 1. yml 구조 사용법에 대한 이해도 부족
- 단순히 설정을 다루는 부분이어서 특정 의존성이나 관련 설정 값 추가시에 해당하는 내용 찾아보면 된다.
- 하지만 그럼에도 아직 yml 작성 원리를 잘 모르고 있어 어렵게 느껴지는 감이 없지않아 있어 이에 대한 학습이 필요해보인다.

## d. 기타 사항
> yml 기초 가이드 [참고](https://www.baeldung.com/spring-boot-yaml-vs-properties)
