### PR TITLE
[#15] EnglishTranscript 생성시 created_at 필드가 자동으로 세팅되지 않는 문제 개선

### DIFF
--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/HarmonyEnglishAcademyApplication.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/HarmonyEnglishAcademyApplication.java
@@ -2,7 +2,9 @@ package com.teamhyeok.harmonyenglishacademy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class HarmonyEnglishAcademyApplication {
 

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
@@ -11,9 +11,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity @Getter @NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class EnglishTranscript {
 
@@ -26,7 +28,7 @@ public class EnglishTranscript {
     private String content;
 
     @CreatedDate
-    @JsonFormat(pattern = "yyyy-mm-dd'T'HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;


### PR DESCRIPTION


## a. 설명
> #3 해결을 위한 개발 사항에 created_at(생성 시간) 필드에 대한 값이 자동으로 적용되지 않은 이슈 발생
- #11 에서 구현된 EnglishTrascript의 created_at 필드에 적용된 @CreateDate를 자동으로 채워넣어 주기 위해 필요한 설정들이 누락되어 이를 해결하기 위한 개선 작업 진행

## b. 작업 내용
> @CreatedDate를 통해 자동으로 생성일자 주입할 때 필요한 설정 적용
- SpringBootApplication이 적용된 메서드에 @EnableJpaAuditing 적용
- EnglishTranscript에 createdAt 필드에 적용된 JsonFormat 패턴의 달 설정이 `mm``으로 잘못 기입된 것 `MM`으로 수정
- EnglishTranscript에 @EntityListeners(AuditingEntityListener.class) 적용



## c. 작업 회고
> 1. 버그 재발 방지 방안
- created_at 처럼 jpa에 의존적으로 생성되는 필드는 꼭 테스트를 통해 확인해보기
- 마찬가지로 프레임워크 레벨에서 관리되는 부분이 존재할 시 꼭 api 호출 테스트 진행할 것

> 2. 강제화 할 수 있는 방안
- 사실 테스트 코드나 직접 api 호출을 하는 부분은 임의대로 안할 수 있는데 이를 강제할 수 있는 방법에 대해 고민필요.

## d. 기타 사항
> 1. [참고사항: Auditing에 대해서](https://medium.com/@vino7tech/spring-boot-auditing-tracking-entity-changes-with-createddate-createddate-lastmodifieddate-f03153b7235a)