### PR TITLE
[#12] EnglishTranscript에 불필요하게 적용된 AccessLevel.PULBIC 옵션 PROTECTED로 변경

### DIFF
--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
@@ -16,7 +16,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @EntityListeners(AuditingEntityListener.class)
-@Entity @Getter @NoArgsConstructor(access = AccessLevel.PUBLIC)
+@Entity @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EnglishTranscript {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## a. 설명
> 1. 생성자를 통한 객체 생성방식은 테스트나 서비스에서 이를 사용하기 위해선 AccessLevel을 Public으로 처리해야 했음
- 생성자를 통한 객체 생성의 경우 AccessLevel을 Protected로 설정할 시에 서비스나 테스트 환경에서 해당 값을 사용 불가
- 때문에 기존 접근 정책은 `AccessLevel.Public` 적용

> 2. `EnglishTranscript`에 빌더 패턴 적용 이후 상기 이유로 `AccessLevel.Public`적용 필요가 없어짐
- 빌더 사용시 Protected를 이용하더라도 외부에서 해당 클래스의 객체를 받을 수 있기에 Protected 로 접근 정책 교체 진행

## b. 작업 내용
- englishTranscript 엔터티의 접근 레벨을 `AccessLevel.PROTECTED` 로 변경



## c. 작업 회고
> 1. 빌더 패턴에  `AccessLevel.Protected`를 적용했을 때의 이점
- 어차피 빌더 패턴 적용하면 여기저기서 객체 생성 가능한건 매한가진데 AccessLevel.Protected를 적용하는게 어떤 이점이 있나라는 궁금증이 생겼다.
- 이에 대한 본인의 견해는 아래와 같다.

```
A. 빌더 사용 강제할 수 있다.
- 기본 생성자를 protected로 제한하면 외부 클래스에서 직접 객체를 생성할 수 없게 된다.
- 덕분에 객체 생성 방식을 빌더 패턴으로 통일할 수 있게 된다. 
- 이런 특징은 필수 필드들이 누락되지 않도록 보장할 수 있다.

B. 기본 생성자 접근 제한
- 빌더 패턴을 사용할 때도 컴파일러는 기본 생성자를 생성한다.
- 근데 이 경우에 접근 제어자가 public이면 외부에서 이를 통해 객체를 생성할 수 있다.
- 따라서 protected로 설정하면 외부에서의 무분별한 기본 객체 생성을 막을 수 있다.

C. JPA 요구사항에 벗어나지 않음
-  JPA는 리플렉션을 통해 엔티티 객체를 생성하기 위해 public 또는 protected 접근 제어자를 가진 기본 생성자를 요구한다.
- 따라서 기본 생성자를 protected로 설정하는 건 JPA의 요구사항을 충족하고 있는 상태이기 때문에 큰 문제가 없다.
```
