### PR TITLE
[#26] 클래스 레벨에 적용되어 있던 @Cacheable 제거

### DIFF
--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/service/EnglishTranscriptService.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/service/EnglishTranscriptService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Cacheable
 @RequiredArgsConstructor @Service
 public class EnglishTranscriptService {
     private final EnglishTranscriptRepository englishTranscriptRepository;


### PR DESCRIPTION
## a. 설명
> #26 문제를 해결하기 위해 @Cacheable 제거

## b. 작업 내용
> 1. 클래스 레벨에 적용한 Cacheable이 cacheName 문제를 야기해 이를 제거
- 명확한 이유 없이 클래스 레벨에 정의되어 있던 @Cacheable로 인해 게시글 등록시 cachename을 찾을 수 없어 에러가 발생하는 버그 해소를 위해 해당 애노테이션 제거

## c. 작업 회고
> 1. 테스트 코드 실행 철저히
- 테스트 코드 실행을 진행했으면 미연에 이런 일을 방지할 수 있었다는 사실을 깨달았고 바쁘더라도 이 내용을 깜빡하지 않게 PR 전에 이를 확인할 수 있는 체크 박스를 PR 템플릿에 추가했다. #28 
- 향후 문제가 재발하거나 여유가 생기는 경우 PR 전에 테스트 자동화하는 스크립트 작성하기로 결정했다.

> 2. 코드의 사용 원리 분명히 이해하고 사용하기
- 아무리 정형화된 스텝이 있는 간단한 설정 코드여도 공식 문서에서 주는 가이드만 보고 따라치는것에 그치지 말고 최소한의 기능은 이해하고 사용토록 하자는 배움을 얻었다.


<br> 


## e. 체크리스트
- [X] 모든 테스트 코드가 성공적으로 통과했는지 확인
<img width="393" alt="image" src="https://github.com/user-attachments/assets/9d0915ff-2865-4727-9bb5-8ad5a52ea33a">


- [X] 개발 내용에 대해 GPT 검수를 완료했는지 확인


