### PR TITLE
[#32] 영어 스크립트 게시글 정보에 유튜브 url을 포함해 내려주도록 변경 및 해당 기능 구현 과정에 필요한 유튜브 api 호출 코드 및 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.json:json:20230227'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
@@ -11,12 +11,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-
-@EntityListeners(AuditingEntityListener.class)
-@Entity @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EnglishTranscript {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,6 +25,8 @@ public class EnglishTranscript {
     @Lob
     private String content;
 
+    private String youtubeUrl;
+
     @CreatedDate
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -34,8 +34,9 @@ public class EnglishTranscript {
     private LocalDateTime createdAt;
 
     @Builder
-    public EnglishTranscript(String title, String content) {
+    public EnglishTranscript(String title, String content, String youtubeUrl) {
         this.title = title;
         this.content = content;
+        this.youtubeUrl = youtubeUrl;
     }
 }

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/request/EnglishTranscriptCreate.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/request/EnglishTranscriptCreate.java
@@ -3,30 +3,38 @@ package com.teamhyeok.harmonyenglishacademy.api.request;
 
 import com.teamhyeok.harmonyenglishacademy.api.domain.EnglishTranscript;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class EnglishTranscriptCreate {
 
-    @NotBlank(message = "영어 스크립트 게시글 등록을 위해선 이름이 필요합니다.")
-    private String title;
+    @NotBlank(message = "영어 스크립트 게시글 등록을 위해선 제목이 필요합니다.")
+    final private String title;
 
     @NotBlank(message = "영어 스크립트 게시글 등록을 위해선 내용이 필요합니다.")
-    private String content;
+    final private String content;
+
+    @NotBlank(message = "YouTube URL은 필수 입력 사항입니다.")  // 빈 문자열인 경우 처리
+    @Pattern(
+            regexp = "^(https?://)?(www\\.)?(youtube\\.com|youtu\\.be)/.+$",
+            message = "유효한 YouTube URL을 입력해주세요."  // 형식이 잘못된 경우 처리
+    )
+    final private String youtubeUrl;
 
     public EnglishTranscript toEntity() {
-
         return EnglishTranscript.builder()
                 .title(title)
                 .content(content)
+                .youtubeUrl(youtubeUrl)
                 .build();
     }
 
     @Builder
-    public EnglishTranscriptCreate(String title, String content) {
+    public EnglishTranscriptCreate(String title, String content, String youtubeUrl) {
         this.title = title;
         this.content = content;
+        this.youtubeUrl = youtubeUrl;
     }
-
 }

--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/service/EnglishTranscriptService.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/service/EnglishTranscriptService.java
@@ -4,19 +4,29 @@ import com.teamhyeok.harmonyenglishacademy.api.domain.EnglishTranscript;
 import com.teamhyeok.harmonyenglishacademy.api.repository.EnglishTranscriptRepository;
 import com.teamhyeok.harmonyenglishacademy.api.request.EnglishTranscriptCreate;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-@RequiredArgsConstructor @Service
+@RequiredArgsConstructor @Service @Slf4j
 public class EnglishTranscriptService {
     private final EnglishTranscriptRepository englishTranscriptRepository;
 
     public void createTranscript(EnglishTranscriptCreate englishTranscriptCreate) {
+
+        validateYouTubeVideo(englishTranscriptCreate.getYoutubeUrl());
 
         englishTranscriptRepository.save(englishTranscriptCreate.toEntity());
 
@@ -36,6 +46,38 @@ public class EnglishTranscriptService {
 
         return pageOfEnglishTranscript.getContent();
 
+    }
+
+    private void validateYouTubeVideo(String youtubeUrl) {
+        String apiKey = System.getenv("YOUTUBE_API_KEY");
+        String videoId = extractVideoId(youtubeUrl);
+
+        String apiUrl = "https://www.googleapis.com/youtube/v3/videos?id=" + videoId + "&key=" + apiKey + "&part=id";
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.getForEntity(apiUrl, String.class);
+
+        log.debug("youtube api 응답" + response);
+
+        try {
+            JSONObject json = new JSONObject(response.getBody());
+            JSONArray items = json.getJSONArray("items");
+            if (items.length() == 0) {
+                throw new IllegalArgumentException("존재하지 않는 YouTube 비디오입니다.");
+            }
+        } catch (JSONException e) {
+            throw new IllegalArgumentException("YouTube API 응답을 처리하는 중 오류가 발생했습니다.");
+        }
+    }
+
+    private String extractVideoId(String youtubeUrl) {
+        String regex = "(?<=v=|youtu\\.be/|embed/)[^&\\n?#]+";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(youtubeUrl);
+        if (matcher.find()) {
+            return matcher.group();
+        } else {
+            throw new IllegalArgumentException("유효한 YouTube URL이 아닙니다.");
+        }
     }
 }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,7 +2,7 @@ TRUNCATE TABLE english_transcript;
 
 SET SESSION cte_max_recursion_depth = 1000000;
 
-INSERT INTO english_transcript (title, content, created_at)
+INSERT INTO english_transcript (title, content, youtube_url, created_at)
 WITH RECURSIVE cte (n) AS
                    (
                        SELECT 1
@@ -45,6 +45,8 @@ SELECT
             '실전 예제로는, "Can I get a glass of water?"와 같은 간단한 문장을 사용하는 방법을 다룹니다. ',
             '지금부터 영어 실력을 향상시키기 위한 다양한 전략을 살펴보겠습니다. 예제 번호: ', CAST(n AS CHAR)
         ) AS content,
+
+    'https://www.youtube.com/watch?v=a57hvjknIcQ' AS youtube_url,
 
     TIMESTAMP(DATE_ADD(NOW(), INTERVAL -FLOOR(RAND(n) * 1825) DAY) + INTERVAL FLOOR(RAND(n) * 86400) SECOND) AS created_at
 FROM cte;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -2,5 +2,6 @@ CREATE TABLE IF NOT EXISTS english_transcript (
                                   id BIGINT AUTO_INCREMENT PRIMARY KEY,
                                   title VARCHAR(255) NOT NULL,
                                   content TEXT,
+                                  youtube_url VARCHAR(255) NOT NULL,
                                   created_at TIMESTAMP
                               );

--- a/src/main/resources/static/js/listing.js
+++ b/src/main/resources/static/js/listing.js
@@ -22,15 +22,18 @@ function renderTranscriptList(transcriptList) {
     $articlesBox.empty();
 
     transcriptList.forEach((transcript) => {
-        const { id, title, content, createdAt } = transcript;
+        const { id, title, content, createdAt, youtubeUrl } = transcript;
 
         const truncatedContent = content.length > 100 ? content.substring(0, 100) + '...' : content;
         const formattedDate = new Date(createdAt).toLocaleDateString();
 
+        const videoId = extractVideoId(youtubeUrl);
+        const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+
         const htmlData = `
         <div class="col">
             <div class="article-card h-100">
-                <img src="/images/announce/postIsNotReady.png" class="article-img-top" alt="Article Image">
+                <img src="${thumbnailUrl}" class="article-img-top" alt="Article Image">
                 <div class="article-body">
                     <a href="detail.html?id=${id}">
                         <h5 class="article-title">${title}</h5>
@@ -43,4 +46,10 @@ function renderTranscriptList(transcriptList) {
 
         $articlesBox.append(htmlData);
     });
+}
+
+function extractVideoId(youtubeUrl) {
+    const regex = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/)([^&\n?#]+)/;
+    const match = youtubeUrl.match(regex);
+    return match && match[1] ? match[1] : null;
 }


### PR DESCRIPTION
## a. 설명
> #### 1. 메인 화면에 노출되는 영어 스크립트 게시글에 썸네일을 유튜브 url을 통해 받아오도록 처리
- #32 이슈의 해결 방안으로 `유튜브 url`을 내려주고 클라이언트에서 해당 url의 videoId를 추출해 썸네일을 노출시키도록 결정함. 
- 이에 대한 기능 개발 및 테스트 코드 작성

## b. 작업 내용
> #### 1. `EnglishTranscript` 엔터티에 youtubeUrl 필드 추가 및 이에 대한 기존 코드 변경처리
- 5b80b27: 엔터티와 생성 요청 클래스에 youtubeUrl 필드를 추가했다.
- f9ef491: 게시글 등록 과정에 url에 대한 유효성 검증 추가
- a5abf92: 기존 테스트 코드에서 `EnglishTranscript` 생성하는 구문에 youtubeUrl 필드 추가
- ddcf757: `EnglishTranscript` 테이블 생성하는 schema.sql에 youtubeUrl 필드 추가 및 테스트 데이터 생성시에 테스를 위한 고정된 유튜브 url 추가


> #### 2. 테스트 케이스 추가
- a5abf92: 유효하지 않은 유튜브 url이 게시글 등록 요청에 들어왔을 때 내려주는 예외에 대한 실패 테스트

> #### 3 Youtube API 연동
- 051b14e: youtube api를 통해 받아온 응답값을 다루기 위해 json 라이브러리 의존성 추가
- f9ef491: 게시글 등록 과정에서 url에 대한 유효성 검증을 위해 youtube api 호출

> #### 4. 유튜브 url의 썸네일을 노출토록 화면 처리
- becf503: 영어 스크립트 게시글을 리스팅할 때 유튜브 url 검증과 비디오 id를 추출함. 추출한 id 기반으로 유튜브 게시글 썸네일을 가져옴


## c. 작업 회고
> 1. 외부 api(youtubeAPI) 연동 과정에서 ..

## d. 기타 사항
> #### 1. 외부 api 호출로 인한 영향도에 대해 이해하고 대응 방법 고민 필요
- 유튜브 api 호출이라는 시스템 외부 의존성이 발생해 테스트 코드에서 이런 외부 의존성을 관리할 방법 고민 필요
- 서비스 레벨에서 저 외부 api 호출로 인한 문제 발생시 어떻게 핸들링 할건지에 대한 고민 필요


> #### 2. 게시글 대표 이미지에 대한 더 좋은 선택 고민 필요
- 향후 서비스 안정화 이후 게시글 대표 이미지를 어떻게 더룰건지에 대한 기획 및 의사결덩 필요
<br> 


## e. 체크리스트
- [ ] 모든 테스트 코드가 성공적으로 통과했는지 확인
- [ ] 개발 내용에 대해 GPT 검수를 완료했는지 확인