### PR TITLE
[#43] 누락된 EnglishTranscript 클래스에 `AuditingEntityListener` 애노테이션 추가 및 …

### DIFF
--- a/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
+++ b/src/main/java/com/teamhyeok/harmonyenglishacademy/api/domain/EnglishTranscript.java
@@ -11,8 +11,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EnglishTranscript {

--- a/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
+++ b/src/test/java/com/teamhyeok/harmonyenglishacademy/api/controller/EnglishTranscriptControllerTest.java
@@ -163,6 +163,7 @@ class EnglishTranscriptControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].title").value(uuidTitle))
                 .andExpect(jsonPath("$[0].youtubeUrl").value(validYoutubeUrl))
+                .andExpect(jsonPath("$[0].createdAt").exists())
                 .andDo(print());
     }
 


### PR DESCRIPTION
## a. 설명
> 1. #39 이슈에 대한 조치 사항

- #32 이슈 개발 과정에서 발생한 `EntityListeners` 누락에 대한 조치사항

## b. 작업 내용
> #### 1. f73a203353b42a1972025365295647b8c2dc95af: 누락된 AuditionEntityListener 복원 및 테스트 코드 작성 
- EnglishTranscript에 AuditingEntityListener 애노테이션 복원
- 같은 실수 발생시 미연에 확인할 수 있는 가능성을 높이기 위해 게시글 생성시 createdAt이 등록되었는지에 대한 테스트 코드 작성


## c. 작업 회고
> 1. 외부 요소와 연관된 필드일 수록 꼼꼼히 체크하자
- 리소스를 생성하는 작업의 경우 생성에 관련된 필드 중 특정 라이브러리에 종속적인 필드는 꼭 테스트 검증이 필요하다.
- AuditingEntityListener 의 경우도 그냥 일괄적으로 전처리 되는 다른 필드들과 다르게 외부 요인 (스프링)에 의해 주입되는 거여서 이런 식으로 사용되는 필드에 대해서는 좀 더 주의깊게 검증 코드를 작성해야겠다.

## d. 기타 사항
> .. 별도 특이사항 없음

<br> 


## e. 체크리스트
- [X] 모든 테스트 코드가 성공적으로 통과했는지 확인
  -  `@AuditingEntityListener`  누락 발생시 테스트 케이스 실패 확인
![image](https://github.com/user-attachments/assets/d3fd9eb2-cadc-4c54-919d-a74d0dd16296)
  - `@AuditingEntityListener` 누락 없을 시 테스트 케이스 성공
![image](https://github.com/user-attachments/assets/ef7c66d5-83a2-41a3-9236-d339efd9c4d2)


- [X] 개발 내용에 대해 GPT 검수를 완료했는지 확인
