### PR TITLE
[#42] 스프링 실행시 sql을 읽는 방식을 UTF-8로 명시

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,7 @@ spring:
     init:
       mode: always
       platform: mysql
+    script-encoding: UTF-8
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## a. 설명
> 1. 일부 윈도우 환경에서 테스트 데이터 생성 과정에 문제 발생

![image](https://github.com/user-attachments/assets/9d1d93ff-355b-4cef-80a7-dd521b101e03)
![image](https://github.com/user-attachments/assets/1365cb0a-e26e-4f74-be78-c9ef56be30fb)


## b. 작업 내용
> 431bd4a51d289f29e7e4be55b2d03efc0ab72bd8: 스프링 실행시 sql을 읽는 방식을 UTF-8로 명시
- application.yml의 sql, script-encoding 설정을 UTF-8로 명시함


## c. 작업 회고
> 1. 개발 환경 통일의 필요성
- 개발 환경이 여러대로 분리되는 경우 생각지도 못한 곳에서 문제가 발생할 수 있다는 걸 새삼 느꼈다.

> 2. 도커 적용 고려
- 로컬에서 도커를 적용하면 문제를 많이 없앨 수 있을 거 같다는 느낌이 들었는데, 개발계 분리하는 시점에 도커가 좀 더 필요한 시점이 왔을 때 이 부분 같이 고려해보자.

## d. 기타 사항
> 1. 윈도우에서 chcp를 통해 확인할 수 있는 코드별 인코딩 매핑 정보
```
65001: UTF-8
949: CP949 (한국어, Windows 기본 문자셋)
437: OEM 미국
1252: ANSI 라틴1 (서유럽)
```


<br> 


## e. 체크리스트
- [X] 모든 테스트 코드가 성공적으로 통과했는지 확인
> #### DB 적재 확인
![image](https://github.com/user-attachments/assets/51e43167-0dfd-4590-b612-f6aab29dd473)

- [X] 개발 내용에 대해 GPT 검수를 완료했는지 확인
